### PR TITLE
Update Boards + Display Boards Testing & Integration Fixes

### DIFF
--- a/Battleship/Battleship/updateBoards.cpp
+++ b/Battleship/Battleship/updateBoards.cpp
@@ -30,7 +30,6 @@
 bool updateBoardAfterAttack(UserData& defender, UserData& attacker, int row, int col)
 {
     std::vector<std::vector<char>> defenderBoard = defender.getOwnBoard();
-    std::vector<std::vector<char>> defenderTrackingBoard = defender.getTrackingBoard();
     std::vector<std::vector<char>> attackerBoard = attacker.getTrackingBoard();
 
     if (defenderBoard.empty() || attackerBoard.empty())
@@ -45,36 +44,29 @@ bool updateBoardAfterAttack(UserData& defender, UserData& attacker, int row, int
         return false;
     }
 
-    char& defenderCell = defenderBoard[row-1][col-1];
-    char& defenderTCell = defenderTrackingBoard[row - 1][col - 1];
-    char& attackerCell = attackerBoard[row-1][col-1];
+    char& defenderCell = defenderBoard[row][col];
+    char& attackerCell = attackerBoard[row][col];
 
-    // Ignore cells that were already attacked before.
-    if (defenderCell == 'X' || defenderCell == 'O')// || defenderCell == '#')
+    if (defenderCell == 'X' || defenderCell == 'O')
     {
         return false;
     }
 
-    // Any non-water cell counts as a hit.
     if (defenderCell != '~')
     {
         defenderCell = 'X';
-        defenderTCell = 'X';
         attackerCell = 'X';
 
         defender.storeOwnBoard(defenderBoard);
-        defender.storeTrackingBoard(defenderTrackingBoard);
-        //attacker.storeTrackingBoard(attackerBoard);
+        attacker.storeTrackingBoard(attackerBoard);
         return true;
     }
 
     defenderCell = 'O';
-    defenderTCell = 'O';
     attackerCell = 'O';
 
     defender.storeOwnBoard(defenderBoard);
-    defender.storeTrackingBoard(defenderTrackingBoard);
-    //attacker.storeTrackingBoard(attackerBoard);
+    attacker.storeTrackingBoard(attackerBoard);
     return false;
 }
 

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
@@ -82,6 +82,7 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
 namespace UnitInegrationTesting
 {
 	// Unit tests for the Update Boards module.
@@ -201,6 +202,54 @@ namespace UnitInegrationTesting
 			bool result = updateBoardAfterAttack(defender, attacker, 0, 0);
 
 			Assert::IsFalse(result);
+		}
+
+		// Checks that ability results update the defender's board.
+		TEST_METHOD(UpdateBoards_updateBoardsAfterAbility_UpdatesDefenderBoard)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			updateBoardsAfterAbility(defender, attacker, 2, 2, 'X');
+
+			std::vector<std::vector<char>> updatedBoard = defender.getOwnBoard();
+			Assert::AreEqual('X', updatedBoard[2][2]);
+		}
+
+		// Checks that ability results update the attacker's tracking board.
+		TEST_METHOD(UpdateBoards_updateBoardsAfterAbility_UpdatesAttackerTrackingBoard)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			updateBoardsAfterAbility(defender, attacker, 3, 3, 'O');
+
+			std::vector<std::vector<char>> trackingBoard = attacker.getTrackingBoard();
+			Assert::AreEqual('O', trackingBoard[3][3]);
+		}
+
+		// Checks that ability updates do nothing when coordinates are invalid.
+		TEST_METHOD(UpdateBoards_updateBoardsAfterAbility_InvalidCoordinatesDoNothing)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			updateBoardsAfterAbility(defender, attacker, -1, 15, 'X');
+
+			std::vector<std::vector<char>> defenderBoard = defender.getOwnBoard();
+			std::vector<std::vector<char>> trackingBoard = attacker.getTrackingBoard();
+
+			Assert::AreEqual('~', defenderBoard[0][0]);
+			Assert::AreEqual('~', trackingBoard[0][0]);
 		}
 	};
 }

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
@@ -360,4 +360,52 @@ namespace UnitInegrationTesting
 			Assert::IsTrue(output.str().find("Jacob") != std::string::npos);
 		}
 	};
+
+	// Integration tests for the Update Boards module.
+	TEST_CLASS(UpdateBoardsIntegrationTests)
+	{
+	public:
+
+		// Checks that a hit updates both the defender's own board and the attacker's tracking board.
+		TEST_METHOD(Integration_UpdateBoards_HitUpdatesBothBoards)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			std::vector<std::vector<char>> defenderBoard = defender.getOwnBoard();
+			defenderBoard[2][3] = 'S';
+			defender.storeOwnBoard(defenderBoard);
+
+			bool result = updateBoardAfterAttack(defender, attacker, 2, 3);
+
+			std::vector<std::vector<char>> updatedDefenderBoard = defender.getOwnBoard();
+			std::vector<std::vector<char>> updatedTrackingBoard = attacker.getTrackingBoard();
+
+			Assert::IsTrue(result);
+			Assert::AreEqual('X', updatedDefenderBoard[2][3]);
+			Assert::AreEqual('X', updatedTrackingBoard[2][3]);
+		}
+
+		// Checks that a miss updates both the defender's own board and the attacker's tracking board.
+		TEST_METHOD(Integration_UpdateBoards_MissUpdatesBothBoards)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			bool result = updateBoardAfterAttack(defender, attacker, 0, 0);
+
+			std::vector<std::vector<char>> updatedDefenderBoard = defender.getOwnBoard();
+			std::vector<std::vector<char>> updatedTrackingBoard = attacker.getTrackingBoard();
+
+			Assert::IsFalse(result);
+			Assert::AreEqual('O', updatedDefenderBoard[0][0]);
+			Assert::AreEqual('O', updatedTrackingBoard[0][0]);
+		}
+	};
 }

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
@@ -322,5 +322,42 @@ namespace UnitInegrationTesting
 
 			Assert::IsTrue(output.str().find("1") != std::string::npos);
 		}
+
+		// Checks that player boards show the own board and tracking board labels.
+		TEST_METHOD(DisplayBoards_displayPlayerBoards_ShowsBoardLabels)
+		{
+			UserData player;
+			player.storeNickname("Jacob");
+			player.storeOwnBoard(createBoard(10));
+			player.storeTrackingBoard(createBoard(10));
+
+			std::ostringstream output;
+			std::basic_streambuf<char>* oldBuffer = std::cout.rdbuf(output.rdbuf());
+
+			displayPlayerBoards(player);
+
+			std::cout.rdbuf(oldBuffer);
+
+			Assert::IsTrue(output.str().find("=== Own Board ===") != std::string::npos);
+			Assert::IsTrue(output.str().find("=== Tracking Board ===") != std::string::npos);
+		}
+
+		// Checks that player board output includes the player's nickname.
+		TEST_METHOD(DisplayBoards_displayPlayerBoards_ShowsNickname)
+		{
+			UserData player;
+			player.storeNickname("Jacob");
+			player.storeOwnBoard(createBoard(10));
+			player.storeTrackingBoard(createBoard(10));
+
+			std::ostringstream output;
+			std::basic_streambuf<char>* oldBuffer = std::cout.rdbuf(output.rdbuf());
+
+			displayPlayerBoards(player);
+
+			std::cout.rdbuf(oldBuffer);
+
+			Assert::IsTrue(output.str().find("Jacob") != std::string::npos);
+		}
 	};
 }

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
@@ -408,4 +408,72 @@ namespace UnitInegrationTesting
 			Assert::AreEqual('O', updatedTrackingBoard[0][0]);
 		}
 	};
+
+	// Integration tests for the Display Boards module.
+	TEST_CLASS(DisplayBoardsIntegrationTests)
+	{
+	public:
+
+		// Checks that displayPlayerBoards shows an updated hit on the tracking board.
+		TEST_METHOD(Integration_DisplayBoards_DisplayPlayerBoardsShowsUpdatedHit)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeNickname("Defender");
+			attacker.storeNickname("Attacker");
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			std::vector<std::vector<char>> defenderBoard = defender.getOwnBoard();
+			defenderBoard[2][3] = 'S';
+			defender.storeOwnBoard(defenderBoard);
+
+			updateBoardAfterAttack(defender, attacker, 2, 3);
+
+			// First confirm the tracking board was actually updated.
+			std::vector<std::vector<char>> trackingBoard = attacker.getTrackingBoard();
+			Assert::AreEqual('X', trackingBoard[2][3]);
+
+			std::ostringstream output;
+			std::basic_streambuf<char>* oldBuffer = std::cout.rdbuf(output.rdbuf());
+
+			displayPlayerBoards(attacker);
+
+			std::cout.rdbuf(oldBuffer);
+
+			Assert::IsTrue(output.str().find("=== Own Board ===") != std::string::npos);
+			Assert::IsTrue(output.str().find("=== Tracking Board ===") != std::string::npos);
+			Assert::IsTrue(output.str().find("Attacker") != std::string::npos);
+		}
+
+		// Checks that displayOpponentBoard shows ability result markers but still hides untouched ships.
+		TEST_METHOD(Integration_DisplayBoards_DisplayOpponentBoardShowsAbilityResultAndHidesShips)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			std::vector<std::vector<char>> defenderBoard = defender.getOwnBoard();
+			defenderBoard[4][4] = 'Q';
+			defender.storeOwnBoard(defenderBoard);
+
+			updateBoardsAfterAbility(defender, attacker, 2, 2, 'O');
+
+			std::ostringstream output;
+			std::basic_streambuf<char>* oldBuffer = std::cout.rdbuf(output.rdbuf());
+
+			displayOpponentBoard(defender);
+
+			std::cout.rdbuf(oldBuffer);
+
+			Assert::IsTrue(output.str().find("=== Opponent Board ===") != std::string::npos);
+			Assert::IsTrue(output.str().find("O") != std::string::npos);
+			Assert::IsTrue(output.str().find("Q") == std::string::npos);
+		}
+	};
 }

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
@@ -292,5 +292,35 @@ namespace UnitInegrationTesting
 
 			Assert::IsTrue(output.str().find('Q') == std::string::npos);
 		}
+
+		// Checks that the board output includes column headers.
+		TEST_METHOD(DisplayBoards_displaySingleBoard_ShowsColumnHeaders)
+		{
+			std::vector<std::vector<char>> board = createBoard(10);
+
+			std::ostringstream output;
+			std::basic_streambuf<char>* oldBuffer = std::cout.rdbuf(output.rdbuf());
+
+			displaySingleBoard(board, false);
+
+			std::cout.rdbuf(oldBuffer);
+
+			Assert::IsTrue(output.str().find("10") != std::string::npos);
+		}
+
+		// Checks that the board output includes row numbers.
+		TEST_METHOD(DisplayBoards_displaySingleBoard_ShowsRowNumbers)
+		{
+			std::vector<std::vector<char>> board = createBoard(10);
+
+			std::ostringstream output;
+			std::basic_streambuf<char>* oldBuffer = std::cout.rdbuf(output.rdbuf());
+
+			displaySingleBoard(board, false);
+
+			std::cout.rdbuf(oldBuffer);
+
+			Assert::IsTrue(output.str().find("1") != std::string::npos);
+		}
 	};
 }

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
@@ -48,8 +48,6 @@ extern "C++" void setResult(bool hit);
 extern "C++" void placeShip(UserData* user, int choice);
 
 //Display Boards - Jacob
-extern "C++" static bool isShipCell(char value);
-extern "C++" static void printColumnHeaders(int boardSize);
 extern "C++" void displaySingleBoard(const std::vector<std::vector<char>>& board, bool hideShips);
 extern "C++" void displayPlayerBoards(UserData& player);
 extern "C++" void displayOpponentBoard(UserData& player);
@@ -79,17 +77,46 @@ extern "C++" Board createBoard(int boardSize);
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
 namespace UnitInegrationTesting
 {
-	TEST_CLASS(UnitInegrationTesting)
+	TEST_CLASS(UpdateBoardsTests)
 	{
 	public:
-		
-		TEST_METHOD(TestMethod1)
+
+		TEST_METHOD(UpdateBoards_updateBoardAfterAttack_HitReturnsTrue)
 		{
-			printf("Test Success\n");
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			std::vector<std::vector<char>> board = defender.getOwnBoard();
+			board[2][3] = 'S';
+			defender.storeOwnBoard(board);
+
+			bool result = updateBoardAfterAttack(defender, attacker, 2, 3);
+
+			Assert::IsTrue(result);
 		}
 
+		TEST_METHOD(UpdateBoards_updateBoardAfterAttack_MissReturnsFalse)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			bool result = updateBoardAfterAttack(defender, attacker, 1, 1);
+
+			Assert::IsFalse(result);
+		}
 	};
 }
-

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
@@ -1,11 +1,14 @@
+#include "pch.h"
+
 //Libraries
 #include <vector>
 #include <iostream>
 #include <string>
 #include <time.h>
+#include <sstream>
+#include <streambuf>
 
 //Files
-#include "pch.h"
 #include "CppUnitTest.h"
 #include "mainMenu.h"
 #include "userInput.h"
@@ -250,6 +253,44 @@ namespace UnitInegrationTesting
 
 			Assert::AreEqual('~', defenderBoard[0][0]);
 			Assert::AreEqual('~', trackingBoard[0][0]);
+		}
+	};
+
+	// Unit tests for the Display Boards module.
+	TEST_CLASS(DisplayBoardsTests)
+	{
+	public:
+
+		// Checks that a board shows ship symbols when hideShips is false.
+		TEST_METHOD(DisplayBoards_displaySingleBoard_ShowsVisibleShips)
+		{
+			std::vector<std::vector<char>> board = createBoard(10);
+			board[0][0] = 'Q';
+
+			std::ostringstream output;
+			std::basic_streambuf<char>* oldBuffer = std::cout.rdbuf(output.rdbuf());
+
+			displaySingleBoard(board, false);
+
+			std::cout.rdbuf(oldBuffer);
+
+			Assert::IsTrue(output.str().find('Q') != std::string::npos);
+		}
+
+		// Checks that ship symbols are hidden when hideShips is true.
+		TEST_METHOD(DisplayBoards_displaySingleBoard_HidesShipsWhenRequested)
+		{
+			std::vector<std::vector<char>> board = createBoard(10);
+			board[0][0] = 'Q';
+
+			std::ostringstream output;
+			std::basic_streambuf<char>* oldBuffer = std::cout.rdbuf(output.rdbuf());
+
+			displaySingleBoard(board, true);
+
+			std::cout.rdbuf(oldBuffer);
+
+			Assert::IsTrue(output.str().find('Q') == std::string::npos);
 		}
 	};
 }

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
@@ -82,7 +82,6 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
-
 namespace UnitInegrationTesting
 {
 	// Unit tests for the Update Boards module.
@@ -158,6 +157,50 @@ namespace UnitInegrationTesting
 
 			std::vector<std::vector<char>> trackingBoard = attacker.getTrackingBoard();
 			Assert::AreEqual('X', trackingBoard[3][2]);
+		}
+
+		// Checks that a miss updates the attacker's tracking board.
+		TEST_METHOD(UpdateBoards_updateBoardAfterAttack_MissMarksAttackerTrackingBoard)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			updateBoardAfterAttack(defender, attacker, 0, 0);
+
+			std::vector<std::vector<char>> trackingBoard = attacker.getTrackingBoard();
+			Assert::AreEqual('O', trackingBoard[0][0]);
+		}
+
+		// Checks that invalid coordinates return false.
+		TEST_METHOD(UpdateBoards_updateBoardAfterAttack_InvalidCoordinatesReturnFalse)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			bool result = updateBoardAfterAttack(defender, attacker, -1, 15);
+
+			Assert::IsFalse(result);
+		}
+
+		// Checks that attacking the same cell again returns false.
+		TEST_METHOD(UpdateBoards_updateBoardAfterAttack_RepeatedAttackReturnsFalse)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			updateBoardAfterAttack(defender, attacker, 0, 0);
+			bool result = updateBoardAfterAttack(defender, attacker, 0, 0);
+
+			Assert::IsFalse(result);
 		}
 	};
 }

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
@@ -85,10 +85,12 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace UnitInegrationTesting
 {
+	// Unit tests for the Update Boards module.
 	TEST_CLASS(UpdateBoardsTests)
 	{
 	public:
 
+		// Checks that a hit returns true.
 		TEST_METHOD(UpdateBoards_updateBoardAfterAttack_HitReturnsTrue)
 		{
 			UserData defender;
@@ -106,6 +108,7 @@ namespace UnitInegrationTesting
 			Assert::IsTrue(result);
 		}
 
+		// Checks that a miss returns false.
 		TEST_METHOD(UpdateBoards_updateBoardAfterAttack_MissReturnsFalse)
 		{
 			UserData defender;

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
@@ -121,5 +121,43 @@ namespace UnitInegrationTesting
 
 			Assert::IsFalse(result);
 		}
+
+		// Checks that a hit updates the defender's board.
+		TEST_METHOD(UpdateBoards_updateBoardAfterAttack_HitMarksDefenderBoard)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			std::vector<std::vector<char>> board = defender.getOwnBoard();
+			board[4][5] = 'B';
+			defender.storeOwnBoard(board);
+
+			updateBoardAfterAttack(defender, attacker, 4, 5);
+
+			std::vector<std::vector<char>> updatedBoard = defender.getOwnBoard();
+			Assert::AreEqual('X', updatedBoard[4][5]);
+		}
+
+		// Checks that a hit updates the attacker's tracking board.
+		TEST_METHOD(UpdateBoards_updateBoardAfterAttack_HitMarksAttackerTrackingBoard)
+		{
+			UserData defender;
+			UserData attacker;
+
+			defender.storeOwnBoard(createBoard(10));
+			attacker.storeTrackingBoard(createBoard(10));
+
+			std::vector<std::vector<char>> board = defender.getOwnBoard();
+			board[3][2] = 'C';
+			defender.storeOwnBoard(board);
+
+			updateBoardAfterAttack(defender, attacker, 3, 2);
+
+			std::vector<std::vector<char>> trackingBoard = attacker.getTrackingBoard();
+			Assert::AreEqual('X', trackingBoard[3][2]);
+		}
 	};
 }

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.cpp
@@ -475,5 +475,23 @@ namespace UnitInegrationTesting
 			Assert::IsTrue(output.str().find("O") != std::string::npos);
 			Assert::IsTrue(output.str().find("Q") == std::string::npos);
 		}
+		// Checks that displaySingleBoard handles unexpected board characters safely.
+		TEST_METHOD(DisplayBoards_displaySingleBoard_InvalidBoardCharacterDoesNotCrash)
+		{
+			std::vector<std::vector<char>> board = createBoard(10);
+			board[2][2] = '@'; // invalid/unexpected symbol
+
+			std::ostringstream output;
+			std::basic_streambuf<char>* oldBuffer = std::cout.rdbuf(output.rdbuf());
+
+			displaySingleBoard(board, false);
+
+			std::cout.rdbuf(oldBuffer);
+
+			// The board should still print, including row/column formatting.
+			Assert::IsTrue(output.str().length() > 0);
+			Assert::IsTrue(output.str().find("1") != std::string::npos);
+		}
+
 	};
 }

--- a/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.vcxproj
+++ b/Battleship/Unit-Inegration-Testing/Unit-Inegration-Testing.vcxproj
@@ -92,14 +92,14 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship;$(VCInstallDir)UnitTest\include;$(SolutionDir)Battleship\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship\x64\Debug;C:\Users\Administrator\source\repos\Battleship_Redo\Battleship\Battleship\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>main.obj;mainMenu.obj;userInput.obj;gatherGameData.obj;placeShips.obj;fileIOSystem.obj;attack.obj;displayBoards.obj;shipChecking.obj;updateBoards.obj;win.obj;helper.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -108,14 +108,14 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship;$(VCInstallDir)UnitTest\include;$(SolutionDir)Battleship\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship\x64\Debug;C:\Users\Administrator\source\repos\Battleship_Redo\Battleship\Battleship\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>main.obj;mainMenu.obj;userInput.obj;gatherGameData.obj;placeShips.obj;fileIOSystem.obj;attack.obj;displayBoards.obj;shipChecking.obj;updateBoards.obj;win.obj;helper.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -126,7 +126,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship;$(VCInstallDir)UnitTest\include;$(SolutionDir)Battleship\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -135,7 +135,7 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship\x64\Debug;C:\Users\Administrator\source\repos\Battleship_Redo\Battleship\Battleship\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>main.obj;mainMenu.obj;userInput.obj;gatherGameData.obj;placeShips.obj;fileIOSystem.obj;attack.obj;displayBoards.obj;shipChecking.obj;updateBoards.obj;win.obj;helper.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -146,7 +146,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship;$(VCInstallDir)UnitTest\include;$(SolutionDir)Battleship\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -155,7 +155,7 @@
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalLibraryDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>C:\Users\Vincent\source\repos\Battleship-Testing\Battleship\Battleship\x64\Debug;C:\Users\Administrator\source\repos\Battleship_Redo\Battleship\Battleship\x64\Debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>main.obj;mainMenu.obj;userInput.obj;gatherGameData.obj;placeShips.obj;fileIOSystem.obj;attack.obj;displayBoards.obj;shipChecking.obj;updateBoards.obj;win.obj;helper.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Finished Update Boards + Display Boards.

Implemented full board update logic (hits, misses, abilities)
Added unit + integration tests (hits, misses, invalid inputs, display output)
Confirmed both defender and attacker boards update correctly
Display functions now correctly show/hide ships and format output

Small note:

Minor changes may affect placeShips/display interaction, nothing major but just be aware when merging

Everything is working with the current testing framework.